### PR TITLE
Feature to store/restore last user input

### DIFF
--- a/src/com/brosinski/eclipse/regex/view/RegExView.java
+++ b/src/com/brosinski/eclipse/regex/view/RegExView.java
@@ -149,6 +149,13 @@ public class RegExView extends ViewPart implements SelectionListener,
             txt_RegExp.addKeyListener(new AssistKeyAdapter());
         
 
+        // GRO: Store/Restore last input value from PreferenceStore
+        IPreferenceStore preferenceStore = RegExPlugin.getDefault().getPreferenceStore();
+        String preferenceKey = "txt_RegExp";
+        txt_RegExp.addFocusListener(new SaveLastValueToPreferenceStoreFocusAdapter(preferenceStore, preferenceKey));
+        txt_RegExp.setText(preferenceStore.getString(preferenceKey));
+        
+        
         txt_RegExp.addFocusListener(new FocusListener() {
 
             private int caretOffset;
@@ -269,6 +276,13 @@ public class RegExView extends ViewPart implements SelectionListener,
 
         txt_SearchText.setMenu(new Menu(parent.getShell()));
         setTextMenuItems(txt_SearchText);
+        
+        
+        // GRO: Store/Restore last input value from PreferenceStore 
+        preferenceKey = "txt_SearchText";
+        txt_SearchText.addFocusListener(new SaveLastValueToPreferenceStoreFocusAdapter(preferenceStore, preferenceKey));
+        txt_SearchText.setText(preferenceStore.getString(preferenceKey));
+
       
 
         txt_Result = new StyledText(sashForm, SWT.LEFT | SWT.MULTI

--- a/src/com/brosinski/eclipse/regex/view/SaveLastValueToPreferenceStoreFocusAdapter.java
+++ b/src/com/brosinski/eclipse/regex/view/SaveLastValueToPreferenceStoreFocusAdapter.java
@@ -1,0 +1,59 @@
+package com.brosinski.eclipse.regex.view;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.FocusAdapter;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * Saves the last text value from a widget when focus is lost to {@link IPreferenceStore}.
+ * PreferenceStore will be automatically saved by
+ * {@link org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)}.
+ * <p>
+ * The current version support only {@link StyledText}, but it can be easily extended, if
+ * needed.
+ * @author Andreas Groll
+ */
+public class SaveLastValueToPreferenceStoreFocusAdapter extends FocusAdapter {
+
+	private final IPreferenceStore preferenceStore;
+	private final String preferenceKey;
+
+	/**
+	 * Constructor.
+	 * @param preferenceStore PreferenceStore to store value.
+	 * @param preferenceKey Name of the key to store value.
+	 */
+	public SaveLastValueToPreferenceStoreFocusAdapter(final IPreferenceStore preferenceStore,
+		final String preferenceKey) {
+
+		this.preferenceStore = preferenceStore;
+		this.preferenceKey = preferenceKey;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void focusLost(final FocusEvent e) {
+
+		// Init
+		String value = null;
+
+		// Current version supports only StyledText and Text, but can be extended, if needed
+		if (e.widget instanceof StyledText) {
+			StyledText styledText = (StyledText)e.widget;
+			value = styledText.getText();
+		} else if (e.widget instanceof Text) {
+			Text text = (Text)e.widget;
+			value = text.getText();
+		} else {
+			// Unusupported widget type
+			return;
+		}
+
+		// Put to preference store
+		preferenceStore.setValue(preferenceKey, value == null ? "" : value);
+	}
+}


### PR DESCRIPTION
I 've made a small change to your nice Plugin, that the last input regular expression (StyledText-Widget) and the searched (StyledText-Widget) are stored using a FocusListener to PreferenceStore and values are restored on start of the plugin.

By the way, for me running eclipse 3.7.2, I had to change dependencies from 3.8 to 3.7.
